### PR TITLE
need a scalar not referenced elsewhere to make the sub inlinable

### DIFF
--- a/lib/constant/tiny.pm
+++ b/lib/constant/tiny.pm
@@ -68,6 +68,7 @@ my $normal_constant_name = qr/^_?[A-Za-z0-9][A-Za-z0-9_]+\z/;
                 $symtab->{$name} = \$scalar;
                 ++$flush_mro;
             } else {
+		my $scalar = $scalar;
                 *$full_name = sub () { $scalar };
             }
         } elsif (@_) {


### PR DESCRIPTION
fixes:

Constants from lexical variables potentially modified elsewhere are deprecated
https://rt.cpan.org/Public/Bug/Display.html?id=103958

This is just the patch provided by bug reporter filed as a pull request.

This was also fixed in a similar manner for the aliased pragma:
https://rt.cpan.org/Public/Bug/Display.html?id=100359#txn-1433423