### PR TITLE
trapped error contains 'Not a HASH reference at ...'

### DIFF
--- a/t/constant.t
+++ b/t/constant.t
@@ -121,7 +121,10 @@ print $output CCODE->($curr_test+4);
 $TB->current_test($curr_test+4);
 
 eval q{ CCODE->{foo} };
-ok scalar($@ =~ /^Constant is not a HASH/);
+ok scalar(grep $@ =~ $_,
+    qr/^Constant is not a HASH/,
+    qr/^Not a HASH reference/,
+);
 
 
 # Allow leading underscore


### PR DESCRIPTION
Check for this message as well as the other (old?) error message.

fixes:

Test suite fails with perl 5.21.4 and newer
https://rt.cpan.org/Public/Bug/Display.html?id=99169

The ticket suggests removing the test, but verifying the error seems
acceptable as well to me.
